### PR TITLE
clang-format@17: Remove installation of shared resources

### DIFF
--- a/Formula/clang-format@17.rb
+++ b/Formula/clang-format@17.rb
@@ -5,6 +5,7 @@ class ClangFormatAT17 < Formula
   url "https://github.com/llvm/llvm-project/releases/download/llvmorg-17.0.3/llvm-17.0.3.src.tar.xz"
   sha256 "18fa6b5f172ddf5af9b3aedfdb58ba070fd07fc45e7e589c46c350b3cc066bc1"
   license "Apache-2.0"
+  revision 1
   version_scheme 1
   head "https://github.com/llvm/llvm-project.git", branch: "main"
 
@@ -74,7 +75,6 @@ class ClangFormatAT17 < Formula
 
     bin.install "build/bin/clang-format" => "clang-format-17"
     bin.install git_clang_format => "git-clang-format-17"
-    (share/"clang").install llvmpath.glob("tools/clang/tools/clang-format/clang-format*")
   end
 
   test do


### PR DESCRIPTION
These resource files are linked unversioned and would clobber the same files provided by other variants of clang-format.