### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test-bot:
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26]
+        os: [ubuntu-24.04, macos-15, macos-26]
     runs-on: ${{ matrix.os }}
     permissions:
       actions: read


### PR DESCRIPTION
Current Homebrew (5.1.15) does not support Ubuntu 22 anymore as its glibc is outdated.